### PR TITLE
chore: update footer copy

### DIFF
--- a/src/components/footer/footer.component.ts
+++ b/src/components/footer/footer.component.ts
@@ -29,8 +29,11 @@ export class LFXFooter extends HTMLElement {
         <div class="footer-content">
           <div class="copyright-container">
             <p class="copyright">Copyright &copy; ${new Date().getFullYear()} The Linux Foundation&reg;. All rights reserved.
-            The Linux Foundation has registered trademarks and uses trademarks. For more information, including terms of use, <a href="https://www.linuxfoundation.org/legal/privacy-policy?hsLang=en" target="_blank">Privacy Policy</a>,
-            and <a href="https://www.linuxfoundation.org/legal/trademark-usage?hsLang=en" target="_blank">Trademark Usage</a>, please see our <a href="https://www.linuxfoundation.org/legal/policies" target="_blank">Policies</a> page.</p>
+            The Linux Foundation has registered trademarks and uses trademarks. For more information, including terms of use,
+            <a href="https://www.linuxfoundation.org/legal/platform-use-agreement/" target="_blank">Platform Usage</a>,
+            <a href="https://www.linuxfoundation.org/legal/privacy-policy?hsLang=en" target="_blank">Privacy Policy</a>,
+            and <a href="https://www.linuxfoundation.org/legal/trademark-usage?hsLang=en" target="_blank">Trademark Usage</a>,
+            please see our <a href="https://www.linuxfoundation.org/legal/policies" target="_blank">Policies</a> page.</p>
           </div>
         </div>
       </div>

--- a/src/components/footer/footer.component.ts
+++ b/src/components/footer/footer.component.ts
@@ -30,10 +30,10 @@ export class LFXFooter extends HTMLElement {
           <div class="copyright-container">
             <p class="copyright">Copyright &copy; ${new Date().getFullYear()} The Linux Foundation&reg;. All rights reserved.
             The Linux Foundation has registered trademarks and uses trademarks. For more information, including terms of use,
-            <a href="https://www.linuxfoundation.org/legal/platform-use-agreement/" target="_blank">Platform Usage</a>,
-            <a href="https://www.linuxfoundation.org/legal/privacy-policy?hsLang=en" target="_blank">Privacy Policy</a>,
-            and <a href="https://www.linuxfoundation.org/legal/trademark-usage?hsLang=en" target="_blank">Trademark Usage</a>,
-            please see our <a href="https://www.linuxfoundation.org/legal/policies" target="_blank">Policies</a> page.</p>
+            <a href="https://www.linuxfoundation.org/legal/platform-use-agreement/" target="_blank" rel="noopener noreferrer">Platform Usage</a>,
+            <a href="https://www.linuxfoundation.org/legal/privacy-policy?hsLang=en" target="_blank" rel="noopener noreferrer">Privacy Policy</a>,
+            and <a href="https://www.linuxfoundation.org/legal/trademark-usage?hsLang=en" target="_blank" rel="noopener noreferrer">Trademark Usage</a>,
+            please see our <a href="https://www.linuxfoundation.org/legal/policies" target="_blank" rel="noopener noreferrer">Policies</a> page.</p>
           </div>
         </div>
       </div>


### PR DESCRIPTION
This pull request includes a small update to the `LFXFooter` component to modify the footer content with updated links.

Changes to footer content:

* [`src/components/footer/footer.component.ts`](diffhunk://#diff-10c3a9cff8a8d64cb7a4792ccd2aeab2d53295ca0caabb29bf56ee56847148f8L32-R36): Updated the footer content to include a new link to the "Platform Usage" agreement and restructured the existing links for better readability.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Updated the footer to link to the "Platform Usage" agreement instead of the "Terms of Use."
	- Enhanced security by adding `rel="noopener noreferrer"` attributes to footer links.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->