### PR TITLE
ci: updated pr title lint

### DIFF
--- a/.github/workflows/_pr-title-lint.yml
+++ b/.github/workflows/_pr-title-lint.yml
@@ -22,6 +22,6 @@ jobs:
           # https://docs.github.com/en/rest/pulls/reviews#dismiss-a-review-for-a-pull-request
           repo-token: '${{ secrets.GITHUB_TOKEN }}'
           # For the meaning of -~, see https://catonmat.net/my-favorite-regex
-          title-regex: '^(build|chore|ci|docs|feat|fix|perf|refactor|revert|style|test)(\([a-z ]+\))?: [ -~]+$'
+          title-regex: '^(build|chore|ci|docs|feat|fix|perf|refactor|revert|style|test)(\([a-z ]+\))?: [a-z][a-z0-9 -~]*[^.]$'
           on-failed-regex-comment: 'PR titles must follow [Conventional Commits](https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md). Love from, Your reviewers ❤️.'
           on-succeeded-regex-dismiss-review-comment: 'Conventional Commits FTW!'

--- a/.github/workflows/_pr-title-lint.yml
+++ b/.github/workflows/_pr-title-lint.yml
@@ -22,6 +22,6 @@ jobs:
           # https://docs.github.com/en/rest/pulls/reviews#dismiss-a-review-for-a-pull-request
           repo-token: '${{ secrets.GITHUB_TOKEN }}'
           # For the meaning of -~, see https://catonmat.net/my-favorite-regex
-          title-regex: '^(build|chore|ci|docs|feat|fix|perf|refactor|revert|style|test)(\([a-z ]+\))?: [a-z][a-z0-9 -~]*[^.]$'
+          title-regex: '^(build|chore|ci|docs|feat|fix|perf|refactor|revert|style|test)(\([a-z ]+\))?: [a-z][a-z0-9 -~]*[^.]\s*$'
           on-failed-regex-comment: 'PR titles must follow [Conventional Commits](https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md). Love from, Your reviewers ❤️.'
           on-succeeded-regex-dismiss-review-comment: 'Conventional Commits FTW!'


### PR DESCRIPTION
This pull request includes a minor change to the PR title validation regex pattern in the `.github/workflows/_pr-title-lint.yml` file. The change ensures that PR titles start with a lowercase letter and do not end with a period.

* `jobs:` in `.github/workflows/_pr-title-lint.yml`: Updated `title-regex` to enforce that PR titles start with a lowercase letter and do not end with a period.