### PR TITLE
feat(components): add embeddable changelog widget

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ npm install @linuxfoundation/lfx-ui-core
   - [Prettier Configuration](docs/prettier-config.md)
 - Components
   - [Components Overview](docs/components.md)
+  - [Changelog Component](docs/changelog.md)
   - [Footer Component](docs/footer.md)
   - [Tools Component](docs/tools.md)
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -184,7 +184,6 @@ export class ChangelogComponent {
 | `--lfx-changelog-accent-bg`        | `#eff6ff`               | Accent background      |
 | `--lfx-changelog-border-radius`    | `12px`                  | Card border radius     |
 | `--lfx-changelog-card-padding`     | `20px`                  | Card padding           |
-| `--lfx-changelog-card-gap`         | `16px`                  | Gap between cards      |
 
 ### Theme Examples
 
@@ -272,7 +271,7 @@ The component references global `--lfx-*` tokens as fallbacks, so it integrates 
 - **High Contrast Support**: Automatic styles for `prefers-contrast: high`
 - **Reduced Motion**: Respects `prefers-reduced-motion` — disables animations
 - **Semantic HTML**: Uses `<article>`, `<time>`, `<h2>`, `<h3>` elements
-- **External Links**: All links include `rel="noopener noreferrer"` and `target="_blank"`
+- **External Links**: Card and footer links include `rel="noopener noreferrer"` and `target="_blank"`. Markdown links with `target="_blank"` are automatically enforced with safe `rel` attributes
 
 ## Responsive Design
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,0 +1,306 @@
+# Changelog Component
+
+The changelog component provides an embeddable widget that displays published changelog entries for LFX products. It fetches data from the changelog API, renders markdown content with XSS protection, and supports light/dark theming.
+
+## Basic Usage
+
+### Angular Implementation
+
+Import the component in your main module (main.ts):
+
+```typescript
+import '@linuxfoundation/lfx-ui-core';
+```
+
+Add `CUSTOM_ELEMENTS_SCHEMA` to your component:
+
+```typescript
+import { CUSTOM_ELEMENTS_SCHEMA, Component } from '@angular/core';
+
+@Component({
+  schemas: [CUSTOM_ELEMENTS_SCHEMA],
+  template: `<lfx-changelog product="easycla"></lfx-changelog>`,
+})
+export class MyComponent {}
+```
+
+### Vue Implementation
+
+Configure custom elements in your vite config or main.ts:
+
+```typescript
+app.config.compilerOptions.isCustomElement = (tag) => tag === 'lfx-changelog';
+```
+
+Then use the component in your template:
+
+```vue
+<script setup>
+import '@linuxfoundation/lfx-ui-core';
+</script>
+
+<template>
+  <lfx-changelog product="easycla" theme="dark"></lfx-changelog>
+</template>
+```
+
+### React Implementation
+
+```typescript
+import '@linuxfoundation/lfx-ui-core';
+
+function App() {
+  return <lfx-changelog product="easycla" theme="dark" limit="5" />;
+}
+```
+
+### VanillaJS Implementation
+
+Import the npm package using unpkg:
+
+```html
+<script src="https://unpkg.com/@linuxfoundation/lfx-ui-core@latest/dist/browser/changelog.bundle.js"></script>
+```
+
+Then, use the component in your HTML:
+
+```html
+<lfx-changelog product="easycla"></lfx-changelog>
+```
+
+## Attributes
+
+| Attribute  | Type   | Required | Default                       | Description                       |
+| ---------- | ------ | -------- | ----------------------------- | --------------------------------- |
+| `product`  | string | Yes      | —                             | Product slug (see table below)    |
+| `theme`    | string | No       | `"light"`                     | `"light"` or `"dark"`             |
+| `limit`    | number | No       | `10`                          | Number of entries to show (max 25)|
+| `base-url` | string | No       | `"https://changelog.lfx.dev"` | Override the API base URL         |
+
+### Available Product Slugs
+
+| Product                 | Slug                      |
+| ----------------------- | ------------------------- |
+| Changelog               | `changelog`               |
+| Community Data Platform | `community-data-platform` |
+| Crowdfunding            | `crowdfunding`            |
+| EasyCLA                 | `easycla`                 |
+| Individual Dashboard    | `individual-dashboard`    |
+| Insights                | `insights`                |
+| Mentorship              | `mentorship`              |
+| Organization Dashboard  | `organization-dashboard`  |
+| Project Control Center  | `project-control-center`  |
+
+## Features
+
+### Light and Dark Theme
+
+Toggle the theme using the `theme` attribute:
+
+```html
+<!-- Light theme (default) -->
+<lfx-changelog product="easycla"></lfx-changelog>
+
+<!-- Dark theme -->
+<lfx-changelog product="easycla" theme="dark"></lfx-changelog>
+```
+
+Theme changes are handled purely via CSS (`:host([theme="dark"])`) — no re-render or API call occurs when switching themes.
+
+### Markdown Rendering
+
+Changelog descriptions support full GitHub Flavored Markdown including headings, lists, code blocks, tables, images, and links. All HTML output is sanitized by DOMPurify for XSS protection.
+
+### Loading, Error, and Empty States
+
+The component handles all states automatically:
+
+- **Loading**: Shows an animated skeleton while fetching data
+- **Error**: Shows an error message with a retry button. Also fires a `changelog-load-error` custom event
+- **Empty**: Shows a "No changelog entries found" message when the API returns zero results
+
+### Error Handling
+
+```javascript
+const changelog = document.querySelector('lfx-changelog');
+
+changelog.addEventListener('changelog-load-error', (event) => {
+  console.error('Changelog load failed:', event.detail.message);
+});
+```
+
+### Framework-Specific Attribute Binding
+
+#### Angular
+
+```typescript
+@Component({
+  schemas: [CUSTOM_ELEMENTS_SCHEMA],
+  template: `
+    <lfx-changelog
+      [attr.product]="productSlug"
+      [attr.theme]="isDark ? 'dark' : 'light'"
+      [attr.limit]="entryLimit"
+      [attr.base-url]="changelogApiUrl">
+    </lfx-changelog>
+  `,
+})
+export class ChangelogComponent {
+  productSlug = 'easycla';
+  isDark = false;
+  entryLimit = 5;
+  changelogApiUrl = environment.changelogApiUrl;
+}
+```
+
+#### Vue
+
+```vue
+<template>
+  <lfx-changelog
+    :product="productSlug"
+    :theme="isDark ? 'dark' : 'light'"
+    :limit="entryLimit"
+    :base-url="changelogApiUrl" />
+</template>
+```
+
+## Styling and Customization
+
+### CSS Custom Properties
+
+| Property                            | Default (light)         | Description            |
+| ----------------------------------- | ----------------------- | ---------------------- |
+| `--lfx-changelog-font-family`      | `system-ui, sans-serif` | Font family            |
+| `--lfx-changelog-font-size-base`   | `14px`                  | Base font size         |
+| `--lfx-changelog-text-primary`     | `#1a1a2e`               | Primary text color     |
+| `--lfx-changelog-text-secondary`   | `#64748b`               | Secondary text color   |
+| `--lfx-changelog-text-muted`       | `#94a3b8`               | Muted text color       |
+| `--lfx-changelog-text-link`        | `#3b82f6`               | Link color             |
+| `--lfx-changelog-bg-surface`       | `#ffffff`               | Background color       |
+| `--lfx-changelog-bg-surface-alt`   | `#f8fafc`               | Alternate background   |
+| `--lfx-changelog-border-color`     | `#e2e8f0`               | Border color           |
+| `--lfx-changelog-accent`           | `#3b82f6`               | Accent color           |
+| `--lfx-changelog-accent-bg`        | `#eff6ff`               | Accent background      |
+| `--lfx-changelog-border-radius`    | `12px`                  | Card border radius     |
+| `--lfx-changelog-card-padding`     | `20px`                  | Card padding           |
+| `--lfx-changelog-card-gap`         | `16px`                  | Gap between cards      |
+
+### Theme Examples
+
+#### Custom Accent Color
+
+```html
+<lfx-changelog
+  product="easycla"
+  style="
+  --lfx-changelog-accent: #10b981;
+  --lfx-changelog-accent-bg: #ecfdf5;
+"></lfx-changelog>
+```
+
+#### Custom Font and Spacing
+
+```html
+<lfx-changelog
+  product="easycla"
+  style="
+  --lfx-changelog-font-family: 'Inter', sans-serif;
+  --lfx-changelog-border-radius: 8px;
+  --lfx-changelog-card-padding: 24px;
+"></lfx-changelog>
+```
+
+### CSS Parts
+
+CSS parts provide fine-grained control over individual elements within the component.
+
+| Part          | Description               |
+| ------------- | ------------------------- |
+| `container`   | Outer wrapper element     |
+| `header`      | Header section            |
+| `heading`     | The h2 heading text       |
+| `list`        | Card list wrapper         |
+| `card`        | Individual changelog card |
+| `meta`        | Version + date row        |
+| `version`     | Version badge             |
+| `date`        | Date text                 |
+| `title`       | Card title                |
+| `description` | Markdown content area     |
+| `footer`      | Footer section            |
+| `link`        | "View all" link           |
+| `loading`     | Loading skeleton          |
+| `error`       | Error state               |
+| `retry`       | Retry button              |
+| `empty`       | Empty state               |
+
+#### CSS Parts Example
+
+```css
+/* Add a left accent border to cards */
+lfx-changelog::part(card) {
+  border-left: 3px solid var(--lfx-changelog-accent);
+}
+
+/* Hide the date */
+lfx-changelog::part(date) {
+  display: none;
+}
+
+/* Custom version badge style */
+lfx-changelog::part(version) {
+  background: #fef3c7;
+  color: #92400e;
+}
+```
+
+### Design Token Integration
+
+The component references global `--lfx-*` tokens as fallbacks, so it integrates with the LFX design system automatically:
+
+```css
+:root {
+  --lfx-font-family: 'Open Sans', sans-serif;
+  --lfx-font-size-base: 14px;
+}
+
+/* The changelog component will pick these up via its internal fallbacks */
+```
+
+## Accessibility Features
+
+- **High Contrast Support**: Automatic styles for `prefers-contrast: high`
+- **Reduced Motion**: Respects `prefers-reduced-motion` — disables animations
+- **Semantic HTML**: Uses `<article>`, `<time>`, `<h2>`, `<h3>` elements
+- **External Links**: All links include `rel="noopener noreferrer"` and `target="_blank"`
+
+## Responsive Design
+
+The component automatically adjusts for mobile devices:
+
+- Reduced padding on screens under 768px
+- Smaller heading font size on mobile
+- Full-width layout with no horizontal overflow
+
+## Development
+
+To develop the component, run the following commands:
+
+```bash
+npm run build
+npm run storybook
+```
+
+**Note**: The Storybook stories point to `http://localhost:4204` for the changelog API. Start the lfx-changelog backend before running Storybook to see live data.
+
+### Available Stories
+
+- **Default** — EasyCLA changelogs
+- **DarkTheme** — Dark color scheme
+- **LimitedEntries** — Show only 3 entries
+- **InsightsProduct** — Insights product changelogs
+- **MentorshipProduct** — Mentorship product changelogs
+- **CustomAccent** — Dark theme with green accent
+- **WithCSSParts** — Advanced styling with CSS parts
+- **ErrorState** — Error display with retry button
+- **MissingProduct** — Error when product attribute is missing

--- a/docs/components.md
+++ b/docs/components.md
@@ -4,6 +4,34 @@ This document provides an overview of all available components in the LFX UI Cor
 
 ## Available Components
 
+### Changelog Component (`lfx-changelog`)
+
+An embeddable changelog widget that fetches and displays published changelog entries for LFX products with markdown rendering and theme support.
+
+**Key Features:**
+
+- **Product Filtering**: Show changelogs for a specific product via the `product` attribute
+- **Light/Dark Theme**: Toggle with the `theme` attribute
+- **Markdown Rendering**: Full GFM markdown with XSS protection (DOMPurify)
+- **Loading States**: Skeleton animation, error with retry, empty states
+- **CSS Custom Properties**: Full theming via `--lfx-changelog-*` properties
+- **CSS Parts**: Fine-grained styling with `::part()` selectors
+
+**Usage:**
+
+```html
+<!-- Basic usage -->
+<lfx-changelog product="easycla"></lfx-changelog>
+
+<!-- With dark theme and limit -->
+<lfx-changelog product="easycla" theme="dark" limit="5"></lfx-changelog>
+
+<!-- With custom API URL -->
+<lfx-changelog product="insights" base-url="https://changelog.lfx.dev"></lfx-changelog>
+```
+
+**Documentation:** [Changelog Component](changelog.md)
+
 ### Footer Component (`lfx-footer`)
 
 A comprehensive footer component that provides consistent copyright and legal information across LFX applications.
@@ -60,15 +88,18 @@ A tools menu component that provides a grid icon button that opens a dropdown me
 
 ## Component Features Overview
 
-| Feature               | Footer | Tools |
-| --------------------- | ------ | ----- |
-| Cookie Tracking       | ✅     | ❌    |
-| CSS Custom Properties | ✅     | ✅    |
-| CSS Parts             | ✅     | ✅    |
-| Accessibility         | ✅     | ✅    |
-| Responsive Design     | ✅     | ✅    |
-| Framework Agnostic    | ✅     | ✅    |
-| TypeScript Support    | ✅     | ✅    |
+| Feature               | Changelog | Footer | Tools |
+| --------------------- | --------- | ------ | ----- |
+| API Data Fetching     | ✅        | ❌     | ❌    |
+| Markdown Rendering    | ✅        | ❌     | ❌    |
+| Light/Dark Theme      | ✅        | ❌     | ❌    |
+| Cookie Tracking       | ❌        | ✅     | ❌    |
+| CSS Custom Properties | ✅        | ✅     | ✅    |
+| CSS Parts             | ✅        | ✅     | ✅    |
+| Accessibility         | ✅        | ✅     | ✅    |
+| Responsive Design     | ✅        | ✅     | ✅    |
+| Framework Agnostic    | ✅        | ✅     | ✅    |
+| TypeScript Support    | ✅        | ✅     | ✅    |
 
 ## Installation and Setup
 
@@ -85,6 +116,7 @@ npm install @linuxfoundation/lfx-ui-core
 import '@linuxfoundation/lfx-ui-core';
 
 // Or import individual components
+import '@linuxfoundation/lfx-ui-core/dist/components/changelog';
 import '@linuxfoundation/lfx-ui-core/dist/components/footer';
 import '@linuxfoundation/lfx-ui-core/dist/components/tools';
 ```

--- a/docs/components.md
+++ b/docs/components.md
@@ -115,10 +115,8 @@ npm install @linuxfoundation/lfx-ui-core
 // Import all components
 import '@linuxfoundation/lfx-ui-core';
 
-// Or import individual components
-import '@linuxfoundation/lfx-ui-core/dist/components/changelog';
-import '@linuxfoundation/lfx-ui-core/dist/components/footer';
-import '@linuxfoundation/lfx-ui-core/dist/components/tools';
+// Or import components module (includes changelog, footer, tools)
+import '@linuxfoundation/lfx-ui-core/components';
 ```
 
 ### Framework Integration

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,10 @@
       "name": "@linuxfoundation/lfx-ui-core",
       "version": "0.0.0",
       "license": "MIT",
+      "dependencies": {
+        "dompurify": "^3.3.3",
+        "marked": "^17.0.5"
+      },
       "devDependencies": {
         "@storybook/addon-essentials": "^8.4.5",
         "@storybook/addon-interactions": "^8.4.5",
@@ -15,6 +19,7 @@
         "@storybook/blocks": "^8.4.5",
         "@storybook/web-components": "^8.4.5",
         "@storybook/web-components-vite": "^8.4.5",
+        "@types/dompurify": "^3.0.5",
         "@types/node": "^20.0.0",
         "@types/prettier": "3.0.0",
         "browserify": "^17.0.0",
@@ -1487,6 +1492,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/dompurify": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@types/dompurify/-/dompurify-3.0.5.tgz",
+      "integrity": "sha512-1Wg0g3BtQF7sSb27fJQAKck1HECM6zV1EB66j8JH9i3LCjYabJa0FSdiSgsD5K/RbrsR0SiraKacLB+T8ZVYAg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/trusted-types": "*"
+      }
+    },
     "node_modules/@types/estree": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.6.tgz",
@@ -1546,7 +1561,7 @@
       "version": "2.0.7",
       "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
       "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/@types/uuid": {
@@ -2578,6 +2593,15 @@
         "npm": ">=1.2"
       }
     },
+    "node_modules/dompurify": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.3.3.tgz",
+      "integrity": "sha512-Oj6pzI2+RqBfFG+qOaOLbFXLQ90ARpcGG6UePL82bJLtdsa6CYJD7nmiU8MW9nQNOtCHV3lZ/Bzq1X0QYbBZCA==",
+      "license": "(MPL-2.0 OR Apache-2.0)",
+      "optionalDependencies": {
+        "@types/trusted-types": "^2.0.7"
+      }
+    },
     "node_modules/duplexer2": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.1.4.tgz",
@@ -3359,6 +3383,18 @@
       "integrity": "sha512-0aF7ZmVon1igznGI4VS30yugpduQW3y3GkcgGJOp7d8x8QrizhigUxjI/m2UojsXXto+jLAH3KSz+xOJTiORjg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/marked": {
+      "version": "17.0.5",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-17.0.5.tgz",
+      "integrity": "sha512-6hLvc0/JEbRjRgzI6wnT2P1XuM1/RrrDEX0kPt0N7jGm1133g6X7DlxFasUIx+72aKAr904GTxhSLDrd5DIlZg==",
+      "license": "MIT",
+      "bin": {
+        "marked": "bin/marked.js"
+      },
+      "engines": {
+        "node": ">= 20"
+      }
     },
     "node_modules/md5.js": {
       "version": "1.3.5",

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "@storybook/blocks": "^8.4.5",
     "@storybook/web-components": "^8.4.5",
     "@storybook/web-components-vite": "^8.4.5",
+    "@types/dompurify": "^3.0.5",
     "@types/node": "^20.0.0",
     "@types/prettier": "3.0.0",
     "browserify": "^17.0.0",
@@ -67,5 +68,9 @@
       "import": "./dist/core/prettier-config/index.js",
       "require": "./dist/core/prettier-config/index.js"
     }
+  },
+  "dependencies": {
+    "dompurify": "^3.3.3",
+    "marked": "^17.0.5"
   }
 }

--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
     }
   },
   "dependencies": {
-    "dompurify": "^3.3.3",
-    "marked": "^17.0.5"
+    "dompurify": "3.3.3",
+    "marked": "17.0.5"
   }
 }

--- a/src/components/changelog/browser.ts
+++ b/src/components/changelog/browser.ts
@@ -1,0 +1,4 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import './changelog.component';

--- a/src/components/changelog/changelog.api.ts
+++ b/src/components/changelog/changelog.api.ts
@@ -1,0 +1,25 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import type { ChangelogApiResponse } from './changelog.types';
+
+/**
+ * Fetch published changelog entries from the public API
+ */
+export async function fetchChangelogs(productSlug: string, limit: number, baseUrl: string, signal?: AbortSignal): Promise<ChangelogApiResponse> {
+  const url = new URL('/public/api/changelogs', baseUrl);
+  url.searchParams.set('productSlug', productSlug);
+  url.searchParams.set('limit', String(limit));
+  url.searchParams.set('page', '1');
+
+  const response = await fetch(url.toString(), {
+    signal,
+    headers: { Accept: 'application/json' },
+  });
+
+  if (!response.ok) {
+    throw new Error(`Failed to fetch changelogs: ${response.status} ${response.statusText}`);
+  }
+
+  return response.json();
+}

--- a/src/components/changelog/changelog.api.ts
+++ b/src/components/changelog/changelog.api.ts
@@ -21,5 +21,16 @@ export async function fetchChangelogs(productSlug: string, limit: number, baseUr
     throw new Error(`Failed to fetch changelogs: ${response.status} ${response.statusText}`);
   }
 
-  return response.json();
+  let data: ChangelogApiResponse;
+  try {
+    data = await response.json();
+  } catch {
+    throw new Error('Failed to parse changelogs response as JSON');
+  }
+
+  if (data && data.success === false) {
+    throw new Error(`Failed to fetch changelogs: ${(data as unknown as Record<string, unknown>).message ?? 'Unknown error'}`);
+  }
+
+  return data;
 }

--- a/src/components/changelog/changelog.component.ts
+++ b/src/components/changelog/changelog.component.ts
@@ -1,0 +1,228 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { StylesheetManager } from '../../core/styles/stylesheet-utils';
+import { fetchChangelogs } from './changelog.api';
+import { renderEmpty, renderError, renderFooter, renderHeader, renderList, renderLoading } from './changelog.renderer';
+import { style } from './changelog.style';
+
+import type { ChangelogEntry } from './changelog.types';
+
+const DEFAULT_BASE_URL = 'https://changelog.lfx.dev';
+const DEFAULT_LIMIT = 10;
+const MAX_LIMIT = 25;
+
+/**
+ * @element lfx-changelog
+ * @summary An embeddable changelog widget for LFX products
+ * @description Fetches and displays published changelog entries for a given LFX product.
+ * Supports light/dark theming, CSS custom properties, and ::part() selectors for styling.
+ * Renders markdown content with XSS protection via DOMPurify.
+ *
+ * @csspart container - Outer wrapper element
+ * @csspart header - Header section
+ * @csspart heading - The h2 heading text
+ * @csspart list - Card list wrapper
+ * @csspart card - Individual changelog card
+ * @csspart meta - Version + date row within a card
+ * @csspart version - Version badge
+ * @csspart date - Date text
+ * @csspart title - Card title
+ * @csspart description - Markdown content area
+ * @csspart footer - Footer section
+ * @csspart link - "View all" link in footer
+ * @csspart loading - Loading skeleton container
+ * @csspart error - Error state container
+ * @csspart retry - Retry button
+ * @csspart empty - Empty state container
+ *
+ * @cssproperty --lfx-changelog-font-family - Font family
+ * @cssproperty --lfx-changelog-font-size-base - Base font size
+ * @cssproperty --lfx-changelog-text-primary - Primary text color
+ * @cssproperty --lfx-changelog-text-secondary - Secondary text color
+ * @cssproperty --lfx-changelog-text-muted - Muted text color
+ * @cssproperty --lfx-changelog-text-link - Link color
+ * @cssproperty --lfx-changelog-bg-surface - Background color
+ * @cssproperty --lfx-changelog-bg-surface-alt - Alternate background color
+ * @cssproperty --lfx-changelog-border-color - Border color
+ * @cssproperty --lfx-changelog-accent - Accent color (version badge, buttons)
+ * @cssproperty --lfx-changelog-accent-bg - Accent background color
+ * @cssproperty --lfx-changelog-border-radius - Card border radius
+ * @cssproperty --lfx-changelog-card-padding - Card padding
+ * @cssproperty --lfx-changelog-card-gap - Gap between cards
+ *
+ * @attr {string} product - Product slug to filter changelogs (required)
+ * @attr {string} theme - Color theme: "light" (default) or "dark"
+ * @attr {number} limit - Max entries to display (1–25, default 10)
+ * @attr {string} base-url - Override the API base URL (defaults to https://changelog.lfx.dev)
+ *
+ * @fires changelog-load-error - Fired when the API request fails
+ */
+export class LFXChangelog extends HTMLElement {
+  private _rendered = false;
+  private _abortController: AbortController | null = null;
+  private _containerElement!: HTMLDivElement;
+
+  static get observedAttributes(): string[] {
+    return ['product', 'theme', 'limit', 'base-url'];
+  }
+
+  constructor() {
+    super();
+    this.attachShadow({ mode: 'open' });
+  }
+
+  // ── Attribute accessors ────────────────────────
+
+  get product(): string {
+    return this.getAttribute('product') || '';
+  }
+
+  get theme(): 'light' | 'dark' {
+    return (this.getAttribute('theme') as 'light' | 'dark') || 'light';
+  }
+
+  get limit(): number {
+    const val = parseInt(this.getAttribute('limit') || '', 10);
+    if (isNaN(val) || val < 1) return DEFAULT_LIMIT;
+    return Math.min(val, MAX_LIMIT);
+  }
+
+  get baseUrl(): string {
+    return this.getAttribute('base-url') || DEFAULT_BASE_URL;
+  }
+
+  // ── Lifecycle ──────────────────────────────────
+
+  connectedCallback(): void {
+    if (!this._rendered) {
+      // Apply styles using StylesheetManager (with caching)
+      StylesheetManager.applyStyles(this.shadowRoot!, style, 'lfx-changelog');
+
+      // Create container
+      this._containerElement = document.createElement('div');
+      this._containerElement.setAttribute('part', 'container');
+      this._containerElement.classList.add('lfx-changelog-container');
+      this.shadowRoot!.appendChild(this._containerElement);
+
+      this._rendered = true;
+    }
+
+    if (!this.product) {
+      this._showError('Missing required "product" attribute');
+      return;
+    }
+    this._loadChangelogs();
+  }
+
+  disconnectedCallback(): void {
+    this._abortController?.abort();
+    this._abortController = null;
+  }
+
+  attributeChangedCallback(name: string, oldValue: string | null, newValue: string | null): void {
+    if (oldValue === newValue) return;
+
+    if (name === 'product' || name === 'limit' || name === 'base-url') {
+      if (!this.isConnected || !this._rendered) return;
+      if (!this.product) {
+        this._abortController?.abort();
+        this._showError('Missing required "product" attribute');
+      } else {
+        this._loadChangelogs();
+      }
+    }
+    // Theme changes are handled via CSS :host([theme="dark"]) — no re-render needed
+  }
+
+  // ── Data loading ───────────────────────────────
+
+  private async _loadChangelogs(): Promise<void> {
+    this._abortController?.abort();
+    this._abortController = new AbortController();
+
+    this._showLoading();
+
+    try {
+      const response = await fetchChangelogs(this.product, this.limit, this.baseUrl, this._abortController.signal);
+
+      if (response.data.length === 0) {
+        this._showEmpty();
+      } else {
+        this._showEntries(response.data);
+      }
+    } catch (error: unknown) {
+      if (error instanceof DOMException && error.name === 'AbortError') return;
+
+      const message = error instanceof Error ? error.message : 'Failed to load changelogs';
+
+      this.dispatchEvent(
+        new CustomEvent('changelog-load-error', {
+          bubbles: true,
+          detail: { message, error },
+        })
+      );
+
+      this._showError(message);
+    }
+  }
+
+  // ── Render states ──────────────────────────────
+
+  private _clearContainer(): void {
+    while (this._containerElement.firstChild) {
+      this._containerElement.removeChild(this._containerElement.firstChild);
+    }
+  }
+
+  private _showLoading(): void {
+    this._clearContainer();
+    this._containerElement.appendChild(renderHeader("What's New"));
+    this._containerElement.appendChild(renderLoading());
+  }
+
+  private _showEntries(entries: ChangelogEntry[]): void {
+    const productName = entries[0]?.product?.name;
+    const heading = productName ? `What's New in ${productName}` : "What's New";
+
+    this._clearContainer();
+    this._containerElement.appendChild(renderHeader(heading));
+
+    const listWrapper = document.createElement('div');
+    listWrapper.setAttribute('part', 'list');
+    listWrapper.classList.add('lfx-changelog-list');
+    listWrapper.appendChild(renderList(entries, this.baseUrl));
+    this._containerElement.appendChild(listWrapper);
+
+    this._containerElement.appendChild(renderFooter(this.baseUrl));
+  }
+
+  private _showError(message: string): void {
+    this._clearContainer();
+    this._containerElement.appendChild(renderHeader("What's New"));
+
+    const errorEl = renderError(message);
+    this._containerElement.appendChild(errorEl);
+
+    const retryBtn = errorEl.querySelector('.lfx-changelog-retry-btn');
+    retryBtn?.addEventListener('click', () => this._loadChangelogs());
+  }
+
+  private _showEmpty(): void {
+    this._clearContainer();
+    this._containerElement.appendChild(renderHeader("What's New"));
+    this._containerElement.appendChild(renderEmpty());
+  }
+}
+
+// Register component
+if (typeof window !== 'undefined' && !customElements.get('lfx-changelog')) {
+  customElements.define('lfx-changelog', LFXChangelog);
+}
+
+// TypeScript declarations for framework integration
+declare global {
+  interface HTMLElementTagNameMap {
+    'lfx-changelog': LFXChangelog;
+  }
+}

--- a/src/components/changelog/changelog.component.ts
+++ b/src/components/changelog/changelog.component.ts
@@ -49,7 +49,6 @@ const MAX_LIMIT = 25;
  * @cssproperty --lfx-changelog-accent-bg - Accent background color
  * @cssproperty --lfx-changelog-border-radius - Card border radius
  * @cssproperty --lfx-changelog-card-padding - Card padding
- * @cssproperty --lfx-changelog-card-gap - Gap between cards
  *
  * @attr {string} product - Product slug to filter changelogs (required)
  * @attr {string} theme - Color theme: "light" (default) or "dark"
@@ -62,6 +61,7 @@ export class LFXChangelog extends HTMLElement {
   private _rendered = false;
   private _abortController: AbortController | null = null;
   private _containerElement!: HTMLDivElement;
+  private _retryHandler: (() => void) | null = null;
 
   static get observedAttributes(): string[] {
     return ['product', 'theme', 'limit', 'base-url'];
@@ -118,6 +118,7 @@ export class LFXChangelog extends HTMLElement {
   disconnectedCallback(): void {
     this._abortController?.abort();
     this._abortController = null;
+    this._cleanupRetryListener();
   }
 
   attributeChangedCallback(name: string, oldValue: string | null, newValue: string | null): void {
@@ -197,7 +198,16 @@ export class LFXChangelog extends HTMLElement {
     this._containerElement.appendChild(renderFooter(this.baseUrl));
   }
 
+  private _cleanupRetryListener(): void {
+    if (this._retryHandler) {
+      const retryBtn = this._containerElement?.querySelector('.lfx-changelog-retry-btn');
+      retryBtn?.removeEventListener('click', this._retryHandler);
+      this._retryHandler = null;
+    }
+  }
+
   private _showError(message: string): void {
+    this._cleanupRetryListener();
     this._clearContainer();
     this._containerElement.appendChild(renderHeader("What's New"));
 
@@ -205,7 +215,8 @@ export class LFXChangelog extends HTMLElement {
     this._containerElement.appendChild(errorEl);
 
     const retryBtn = errorEl.querySelector('.lfx-changelog-retry-btn');
-    retryBtn?.addEventListener('click', () => this._loadChangelogs());
+    this._retryHandler = () => this._loadChangelogs();
+    retryBtn?.addEventListener('click', this._retryHandler);
   }
 
   private _showEmpty(): void {
@@ -226,3 +237,10 @@ declare global {
     'lfx-changelog': LFXChangelog;
   }
 }
+
+// Explicit registration for consumers who need deferred registration
+export const defineChangelog = () => {
+  if (typeof window !== 'undefined' && !customElements.get('lfx-changelog')) {
+    customElements.define('lfx-changelog', LFXChangelog);
+  }
+};

--- a/src/components/changelog/changelog.renderer.ts
+++ b/src/components/changelog/changelog.renderer.ts
@@ -1,0 +1,167 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import DOMPurify from 'dompurify';
+import { marked } from 'marked';
+
+import type { ChangelogEntry } from './changelog.types';
+
+marked.setOptions({
+  async: false,
+  gfm: true,
+  breaks: true,
+});
+
+function _formatDate(dateStr: string): string {
+  try {
+    return new Date(dateStr).toLocaleDateString('en-US', {
+      year: 'numeric',
+      month: 'short',
+      day: 'numeric',
+    });
+  } catch {
+    return dateStr;
+  }
+}
+
+function _sanitizeMarkdown(md: string): string {
+  const rawHtml = marked.parse(md) as string;
+  return DOMPurify.sanitize(rawHtml, {
+    ADD_ATTR: ['target', 'rel'],
+  });
+}
+
+/**
+ * Safely sets DOMPurify-sanitized HTML content on an element.
+ * Uses a template element to parse the sanitized HTML into DOM nodes,
+ * then appends the cloned nodes — avoiding direct innerHTML assignment
+ * on the target element.
+ */
+function _setSanitizedContent(element: HTMLElement, sanitizedHtml: string): void {
+  const template = document.createElement('template');
+  // Content is sanitized by DOMPurify in _sanitizeMarkdown() above
+  template.innerHTML = sanitizedHtml; // nosec: DOMPurify-sanitized
+  element.appendChild(template.content.cloneNode(true));
+}
+
+/**
+ * Create an element with attributes and children
+ */
+function _el<K extends keyof HTMLElementTagNameMap>(tag: K, attrs?: Record<string, string>, children?: (Node | string)[]): HTMLElementTagNameMap[K] {
+  const element = document.createElement(tag);
+  if (attrs) {
+    for (const [key, value] of Object.entries(attrs)) {
+      element.setAttribute(key, value);
+    }
+  }
+  if (children) {
+    for (const child of children) {
+      element.append(typeof child === 'string' ? document.createTextNode(child) : child);
+    }
+  }
+  return element;
+}
+
+/**
+ * Render a single changelog card
+ */
+export function renderCard(entry: ChangelogEntry, baseUrl: string): HTMLElement {
+  const entryUrl = `${baseUrl}/entry/${encodeURIComponent(entry.slug || entry.id)}`;
+  const rawDate = entry.publishedAt ?? entry.createdAt;
+  const dateStr = String(rawDate);
+  const date = _formatDate(dateStr);
+
+  const metaChildren: (Node | string)[] = [];
+  if (entry.version) {
+    metaChildren.push(_el('span', { part: 'version', class: 'lfx-changelog-version' }, [`v${entry.version}`]));
+  }
+  metaChildren.push(_el('time', { part: 'date', class: 'lfx-changelog-date', datetime: dateStr }, [date]));
+
+  const link = _el(
+    'a',
+    {
+      class: 'lfx-changelog-card-link',
+      href: entryUrl,
+      target: '_blank',
+      rel: 'noopener noreferrer',
+    },
+    [_el('div', { part: 'meta', class: 'lfx-changelog-meta' }, metaChildren), _el('h3', { part: 'title', class: 'lfx-changelog-title' }, [entry.title])]
+  );
+
+  const description = _el('div', { part: 'description', class: 'lfx-changelog-description' });
+  _setSanitizedContent(description, _sanitizeMarkdown(entry.description));
+
+  return _el('article', { part: 'card', class: 'lfx-changelog-card' }, [link, description]);
+}
+
+/**
+ * Render a list of changelog cards into a DocumentFragment
+ */
+export function renderList(entries: ChangelogEntry[], baseUrl: string): DocumentFragment {
+  const fragment = document.createDocumentFragment();
+  for (const entry of entries) {
+    fragment.appendChild(renderCard(entry, baseUrl));
+  }
+  return fragment;
+}
+
+/**
+ * Render the loading skeleton
+ */
+export function renderLoading(): HTMLElement {
+  const container = _el('div', { part: 'loading', class: 'lfx-changelog-loading' });
+  for (let i = 0; i < 3; i++) {
+    const skeleton = _el('div', { class: 'lfx-changelog-skeleton' });
+    for (let j = 0; j < 4; j++) {
+      skeleton.appendChild(_el('div', { class: 'lfx-changelog-skeleton-line' }));
+    }
+    container.appendChild(skeleton);
+  }
+  return container;
+}
+
+/**
+ * Render the error state with retry button
+ */
+export function renderError(message: string): HTMLElement {
+  const retryBtn = _el('button', { part: 'retry', class: 'lfx-changelog-retry-btn' }, ['Retry']);
+
+  return _el('div', { part: 'error', class: 'lfx-changelog-error' }, [
+    _el('div', { class: 'lfx-changelog-error-icon' }, ['\u26A0']),
+    _el('div', { class: 'lfx-changelog-error-message' }, [message]),
+    retryBtn,
+  ]);
+}
+
+/**
+ * Render the empty state
+ */
+export function renderEmpty(): HTMLElement {
+  return _el('div', { part: 'empty', class: 'lfx-changelog-empty' }, ['No changelog entries found.']);
+}
+
+/**
+ * Render the footer with "View all" link
+ */
+export function renderFooter(baseUrl: string): HTMLElement {
+  return _el('div', { part: 'footer', class: 'lfx-changelog-footer' }, [
+    _el(
+      'a',
+      {
+        part: 'link',
+        class: 'lfx-changelog-footer-link',
+        href: baseUrl,
+        target: '_blank',
+        rel: 'noopener noreferrer',
+      },
+      ['View all changelogs \u2192']
+    ),
+  ]);
+}
+
+/**
+ * Render the header section
+ */
+export function renderHeader(text: string): HTMLElement {
+  return _el('div', { part: 'header', class: 'lfx-changelog-header' }, [_el('h2', { part: 'heading', class: 'lfx-changelog-heading' }, [text])]);
+}

--- a/src/components/changelog/changelog.renderer.ts
+++ b/src/components/changelog/changelog.renderer.ts
@@ -2,11 +2,11 @@
 // SPDX-License-Identifier: MIT
 
 import DOMPurify from 'dompurify';
-import { marked } from 'marked';
+import { Marked } from 'marked';
 
 import type { ChangelogEntry } from './changelog.types';
 
-marked.setOptions({
+const _marked = new Marked({
   async: false,
   gfm: true,
   breaks: true,
@@ -25,10 +25,22 @@ function _formatDate(dateStr: string): string {
 }
 
 function _sanitizeMarkdown(md: string): string {
-  const rawHtml = marked.parse(md) as string;
-  return DOMPurify.sanitize(rawHtml, {
+  const rawHtml = _marked.parse(md) as string;
+
+  // Enforce rel="noopener noreferrer" on any link with target="_blank"
+  // to prevent reverse-tabnabbing attacks from markdown content
+  DOMPurify.addHook('afterSanitizeAttributes', (node) => {
+    if (node.tagName === 'A' && node.getAttribute('target') === '_blank') {
+      node.setAttribute('rel', 'noopener noreferrer');
+    }
+  });
+
+  const sanitized = DOMPurify.sanitize(rawHtml, {
     ADD_ATTR: ['target', 'rel'],
   });
+
+  DOMPurify.removeHook('afterSanitizeAttributes');
+  return sanitized;
 }
 
 /**
@@ -124,7 +136,7 @@ export function renderLoading(): HTMLElement {
  * Render the error state with retry button
  */
 export function renderError(message: string): HTMLElement {
-  const retryBtn = _el('button', { part: 'retry', class: 'lfx-changelog-retry-btn' }, ['Retry']);
+  const retryBtn = _el('button', { type: 'button', part: 'retry', class: 'lfx-changelog-retry-btn' }, ['Retry']);
 
   return _el('div', { part: 'error', class: 'lfx-changelog-error' }, [
     _el('div', { class: 'lfx-changelog-error-icon' }, ['\u26A0']),

--- a/src/components/changelog/changelog.stories.ts
+++ b/src/components/changelog/changelog.stories.ts
@@ -61,7 +61,6 @@ An embeddable changelog widget for LFX products. Fetches and displays published 
 
 ## Required Attributes
 - \`product\` — Product slug to filter changelogs
-- \`base-url\` — API base URL for the changelog service
 
 ## Available Product Slugs
 \`changelog\`, \`community-data-platform\`, \`crowdfunding\`, \`easycla\`, \`individual-dashboard\`, \`insights\`, \`mentorship\`, \`organization-dashboard\`, \`project-control-center\`

--- a/src/components/changelog/changelog.stories.ts
+++ b/src/components/changelog/changelog.stories.ts
@@ -1,0 +1,263 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { Meta, StoryObj } from '@storybook/web-components';
+import { html } from 'lit';
+import './changelog.component';
+
+/**
+ * Local dev server URL for the changelog API.
+ * Start the lfx-changelog backend (`yarn start` in the lfx-changelog repo)
+ * before running Storybook to see live data.
+ */
+const LOCAL_BASE_URL = 'http://localhost:4204';
+
+interface ChangelogCSSProps {
+  product?: string;
+  theme?: 'light' | 'dark';
+  limit?: number;
+  'base-url'?: string;
+  '--lfx-changelog-font-family'?: string;
+  '--lfx-changelog-text-primary'?: string;
+  '--lfx-changelog-text-secondary'?: string;
+  '--lfx-changelog-bg-surface'?: string;
+  '--lfx-changelog-bg-surface-alt'?: string;
+  '--lfx-changelog-border-color'?: string;
+  '--lfx-changelog-accent'?: string;
+  '--lfx-changelog-accent-bg'?: string;
+  '--lfx-changelog-border-radius'?: string;
+  '--lfx-changelog-card-padding'?: string;
+  [key: string]: any;
+}
+
+const meta: Meta<ChangelogCSSProps> = {
+  title: 'Components/Changelog',
+  component: 'lfx-changelog',
+  parameters: {
+    layout: 'padded',
+    docs: {
+      description: {
+        component: `
+An embeddable changelog widget for LFX products. Fetches and displays published changelog entries with markdown rendering, light/dark theme support, and full style customization.
+
+## Features
+- **Product filtering**: Show changelogs for a specific LFX product via the \`product\` attribute
+- **Light/Dark theme**: Toggle with the \`theme\` attribute
+- **Markdown rendering**: Full GFM markdown support with XSS protection (DOMPurify)
+- **Loading states**: Skeleton loading animation
+- **Error handling**: Error display with retry button
+- **CSS custom properties**: Override colors, fonts, spacing
+- **\`::part()\` selectors**: Style internal elements from outside
+
+## Usage
+\`\`\`html
+<lfx-changelog
+  product="easycla"
+  base-url="https://changelog.lfx.dev"
+  theme="dark"
+  limit="5"
+></lfx-changelog>
+\`\`\`
+
+## Required Attributes
+- \`product\` — Product slug to filter changelogs
+- \`base-url\` — API base URL for the changelog service
+
+## Available Product Slugs
+\`changelog\`, \`community-data-platform\`, \`crowdfunding\`, \`easycla\`, \`individual-dashboard\`, \`insights\`, \`mentorship\`, \`organization-dashboard\`, \`project-control-center\`
+        `,
+      },
+    },
+  },
+  argTypes: {
+    product: {
+      control: { type: 'select' },
+      options: [
+        'changelog',
+        'community-data-platform',
+        'crowdfunding',
+        'easycla',
+        'individual-dashboard',
+        'insights',
+        'mentorship',
+        'organization-dashboard',
+        'project-control-center',
+      ],
+      description: 'Product slug to filter changelogs (required)',
+      table: { category: 'Attributes' },
+    },
+    theme: {
+      control: { type: 'select' },
+      options: ['light', 'dark'],
+      description: 'Color theme',
+      table: { category: 'Attributes' },
+    },
+    limit: {
+      control: { type: 'number', min: 1, max: 25 },
+      description: 'Maximum number of entries to show',
+      table: { category: 'Attributes' },
+    },
+    'base-url': {
+      control: 'text',
+      description: 'Override the API base URL (defaults to prod)',
+      table: { category: 'Attributes' },
+    },
+    '--lfx-changelog-font-family': {
+      control: 'text',
+      description: 'Font family',
+      table: { category: 'CSS Custom Properties' },
+    },
+    '--lfx-changelog-text-primary': {
+      control: 'color',
+      description: 'Primary text color',
+      table: { category: 'CSS Custom Properties' },
+    },
+    '--lfx-changelog-bg-surface': {
+      control: 'color',
+      description: 'Background color',
+      table: { category: 'CSS Custom Properties' },
+    },
+    '--lfx-changelog-accent': {
+      control: 'color',
+      description: 'Accent color',
+      table: { category: 'CSS Custom Properties' },
+    },
+    '--lfx-changelog-border-radius': {
+      control: 'text',
+      description: 'Card border radius',
+      table: { category: 'CSS Custom Properties' },
+    },
+    '--lfx-changelog-card-padding': {
+      control: 'text',
+      description: 'Card padding',
+      table: { category: 'CSS Custom Properties' },
+    },
+  },
+  render: (args) => {
+    const styles = Object.entries(args)
+      .filter(([key, value]) => key.startsWith('--') && value)
+      .map(([key, value]) => `${key}: ${value}`)
+      .join('; ');
+
+    return html`
+      <lfx-changelog
+        style="${styles}"
+        product="${args.product || ''}"
+        theme="${args.theme || 'light'}"
+        limit="${args.limit || 10}"
+        base-url="${args['base-url'] || ''}"></lfx-changelog>
+    `;
+  },
+};
+
+export default meta;
+type Story = StoryObj<ChangelogCSSProps>;
+
+// Default — EasyCLA changelogs via local dev server
+export const Default: Story = {
+  args: {
+    product: 'easycla',
+    'base-url': LOCAL_BASE_URL,
+  },
+};
+
+// Dark theme
+export const DarkTheme: Story = {
+  args: {
+    product: 'easycla',
+    'base-url': LOCAL_BASE_URL,
+    theme: 'dark',
+  },
+  parameters: {
+    backgrounds: { default: 'dark' },
+  },
+};
+
+// Limited entries
+export const LimitedEntries: Story = {
+  args: {
+    product: 'insights',
+    'base-url': LOCAL_BASE_URL,
+    limit: 3,
+  },
+};
+
+// Insights product
+export const InsightsProduct: Story = {
+  args: {
+    product: 'insights',
+    'base-url': LOCAL_BASE_URL,
+  },
+};
+
+// Mentorship product
+export const MentorshipProduct: Story = {
+  args: {
+    product: 'mentorship',
+    'base-url': LOCAL_BASE_URL,
+  },
+};
+
+// Dark theme with custom accent
+export const CustomAccent: Story = {
+  args: {
+    product: 'easycla',
+    'base-url': LOCAL_BASE_URL,
+    theme: 'dark',
+    '--lfx-changelog-accent': '#10b981',
+    '--lfx-changelog-accent-bg': '#064e3b',
+  },
+  parameters: {
+    backgrounds: { default: 'dark' },
+  },
+};
+
+// CSS Parts example
+export const WithCSSParts: Story = {
+  render: () => html`
+    <style>
+      .parts-demo lfx-changelog::part(card) {
+        border-left: 3px solid #3b82f6;
+      }
+
+      .parts-demo lfx-changelog::part(heading) {
+        font-style: italic;
+      }
+
+      .parts-demo lfx-changelog::part(version) {
+        background: #fef3c7;
+        color: #92400e;
+      }
+    </style>
+    <div class="parts-demo">
+      <lfx-changelog product="easycla" base-url="${LOCAL_BASE_URL}" limit="3"></lfx-changelog>
+    </div>
+  `,
+};
+
+// Error state (invalid base URL)
+export const ErrorState: Story = {
+  args: {
+    product: 'easycla',
+    'base-url': 'https://invalid.example.com',
+  },
+  parameters: {
+    docs: {
+      description: {
+        story: 'Demonstrates the error state when the API is unreachable. Includes a retry button.',
+      },
+    },
+  },
+};
+
+// Missing product (shows error)
+export const MissingProduct: Story = {
+  render: () => html` <lfx-changelog base-url="${LOCAL_BASE_URL}"></lfx-changelog> `,
+  parameters: {
+    docs: {
+      description: {
+        story: 'Shows the error state when the required `product` attribute is missing.',
+      },
+    },
+  },
+};

--- a/src/components/changelog/changelog.style.ts
+++ b/src/components/changelog/changelog.style.ts
@@ -31,7 +31,6 @@ export const style = `
   --lfx-changelog-border-radius: 12px;
   --lfx-changelog-border-radius-sm: 6px;
   --lfx-changelog-card-padding: 20px;
-  --lfx-changelog-card-gap: 16px;
 
   font-family: var(--lfx-changelog-font-family);
   font-size: var(--lfx-changelog-font-size-base);

--- a/src/components/changelog/changelog.style.ts
+++ b/src/components/changelog/changelog.style.ts
@@ -1,0 +1,389 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+export const style = `
+:host {
+  display: block;
+
+  /* Typography */
+  --lfx-changelog-font-family: var(--lfx-font-family, system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif);
+  --lfx-changelog-font-size-base: var(--lfx-font-size-base, 14px);
+  --lfx-changelog-font-size-sm: 12px;
+  --lfx-changelog-font-size-lg: 16px;
+  --lfx-changelog-font-size-xl: 20px;
+  --lfx-changelog-line-height: 1.6;
+
+  /* Colors — light defaults */
+  --lfx-changelog-text-primary: #1a1a2e;
+  --lfx-changelog-text-secondary: #64748b;
+  --lfx-changelog-text-muted: #94a3b8;
+  --lfx-changelog-text-link: #3b82f6;
+  --lfx-changelog-text-link-hover: #2563eb;
+  --lfx-changelog-bg-surface: #ffffff;
+  --lfx-changelog-bg-surface-alt: #f8fafc;
+  --lfx-changelog-border-color: #e2e8f0;
+  --lfx-changelog-border-color-strong: #cbd5e1;
+  --lfx-changelog-accent: #3b82f6;
+  --lfx-changelog-accent-bg: #eff6ff;
+  --lfx-changelog-code-bg: #f1f5f9;
+
+  /* Layout */
+  --lfx-changelog-border-radius: 12px;
+  --lfx-changelog-border-radius-sm: 6px;
+  --lfx-changelog-card-padding: 20px;
+  --lfx-changelog-card-gap: 16px;
+
+  font-family: var(--lfx-changelog-font-family);
+  font-size: var(--lfx-changelog-font-size-base);
+  line-height: var(--lfx-changelog-line-height);
+  color: var(--lfx-changelog-text-primary);
+}
+
+/* Dark theme */
+:host([theme="dark"]) {
+  --lfx-changelog-text-primary: #f1f5f9;
+  --lfx-changelog-text-secondary: #94a3b8;
+  --lfx-changelog-text-muted: #64748b;
+  --lfx-changelog-text-link: #60a5fa;
+  --lfx-changelog-text-link-hover: #93bbfd;
+  --lfx-changelog-bg-surface: #1e293b;
+  --lfx-changelog-bg-surface-alt: #0f172a;
+  --lfx-changelog-border-color: #334155;
+  --lfx-changelog-border-color-strong: #475569;
+  --lfx-changelog-accent: #60a5fa;
+  --lfx-changelog-accent-bg: #1e3a5f;
+  --lfx-changelog-code-bg: #1e293b;
+}
+
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+.lfx-changelog-container {
+  background: var(--lfx-changelog-bg-surface);
+  border-radius: var(--lfx-changelog-border-radius);
+  border: 1px solid var(--lfx-changelog-border-color);
+  overflow: hidden;
+}
+
+/* ── Header ───────────────────────────────────── */
+
+.lfx-changelog-header {
+  padding: var(--lfx-changelog-card-padding);
+  border-bottom: 1px solid var(--lfx-changelog-border-color);
+  background: var(--lfx-changelog-bg-surface-alt);
+}
+
+.lfx-changelog-heading {
+  font-size: var(--lfx-changelog-font-size-xl);
+  font-weight: 700;
+  color: var(--lfx-changelog-text-primary);
+  margin: 0;
+}
+
+/* ── Card list ────────────────────────────────── */
+
+.lfx-changelog-list {
+  display: flex;
+  flex-direction: column;
+}
+
+.lfx-changelog-card {
+  padding: var(--lfx-changelog-card-padding);
+  border-bottom: 1px solid var(--lfx-changelog-border-color);
+  transition: background-color 0.15s ease;
+}
+
+.lfx-changelog-card:last-child {
+  border-bottom: none;
+}
+
+.lfx-changelog-card:hover {
+  background: var(--lfx-changelog-bg-surface-alt);
+}
+
+.lfx-changelog-card-link {
+  text-decoration: none;
+  color: inherit;
+  display: block;
+}
+
+.lfx-changelog-meta {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 8px;
+  margin-bottom: 8px;
+}
+
+.lfx-changelog-version {
+  display: inline-flex;
+  align-items: center;
+  padding: 2px 8px;
+  font-size: var(--lfx-changelog-font-size-sm);
+  font-weight: 600;
+  color: var(--lfx-changelog-accent);
+  background: var(--lfx-changelog-accent-bg);
+  border-radius: 9999px;
+}
+
+.lfx-changelog-date {
+  font-size: var(--lfx-changelog-font-size-sm);
+  color: var(--lfx-changelog-text-muted);
+}
+
+.lfx-changelog-title {
+  font-size: var(--lfx-changelog-font-size-lg);
+  font-weight: 600;
+  color: var(--lfx-changelog-text-primary);
+  margin-bottom: 8px;
+}
+
+.lfx-changelog-description {
+  color: var(--lfx-changelog-text-secondary);
+  font-size: var(--lfx-changelog-font-size-base);
+  line-height: var(--lfx-changelog-line-height);
+}
+
+/* ── Markdown content styling ─────────────────── */
+
+.lfx-changelog-description h1,
+.lfx-changelog-description h2,
+.lfx-changelog-description h3,
+.lfx-changelog-description h4 {
+  color: var(--lfx-changelog-text-primary);
+  font-weight: 600;
+  margin: 12px 0 8px;
+}
+
+.lfx-changelog-description h1 { font-size: 1.25em; }
+.lfx-changelog-description h2 { font-size: 1.15em; }
+.lfx-changelog-description h3 { font-size: 1.05em; }
+
+.lfx-changelog-description p {
+  margin: 8px 0;
+}
+
+.lfx-changelog-description ul,
+.lfx-changelog-description ol {
+  padding-left: 1.5em;
+  margin: 8px 0;
+}
+
+.lfx-changelog-description li {
+  margin: 4px 0;
+}
+
+.lfx-changelog-description code {
+  background: var(--lfx-changelog-code-bg);
+  padding: 2px 5px;
+  border-radius: 3px;
+  font-size: 0.9em;
+}
+
+.lfx-changelog-description pre {
+  background: var(--lfx-changelog-code-bg);
+  padding: 12px;
+  border-radius: var(--lfx-changelog-border-radius-sm);
+  overflow-x: auto;
+  margin: 8px 0;
+}
+
+.lfx-changelog-description pre code {
+  background: none;
+  padding: 0;
+}
+
+.lfx-changelog-description a {
+  color: var(--lfx-changelog-text-link);
+  text-decoration: none;
+}
+
+.lfx-changelog-description a:hover {
+  color: var(--lfx-changelog-text-link-hover);
+  text-decoration: underline;
+}
+
+.lfx-changelog-description blockquote {
+  border-left: 3px solid var(--lfx-changelog-border-color-strong);
+  padding-left: 12px;
+  margin: 8px 0;
+  color: var(--lfx-changelog-text-secondary);
+}
+
+.lfx-changelog-description img {
+  max-width: 100%;
+  height: auto;
+  border-radius: var(--lfx-changelog-border-radius-sm);
+  margin: 8px 0;
+}
+
+.lfx-changelog-description table {
+  border-collapse: collapse;
+  width: 100%;
+  margin: 8px 0;
+}
+
+.lfx-changelog-description th,
+.lfx-changelog-description td {
+  border: 1px solid var(--lfx-changelog-border-color);
+  padding: 6px 12px;
+  text-align: left;
+}
+
+.lfx-changelog-description th {
+  background: var(--lfx-changelog-bg-surface-alt);
+  font-weight: 600;
+}
+
+.lfx-changelog-description hr {
+  border: none;
+  border-top: 1px solid var(--lfx-changelog-border-color);
+  margin: 16px 0;
+}
+
+/* ── Footer ───────────────────────────────────── */
+
+.lfx-changelog-footer {
+  padding: var(--lfx-changelog-card-padding);
+  border-top: 1px solid var(--lfx-changelog-border-color);
+  background: var(--lfx-changelog-bg-surface-alt);
+  text-align: center;
+}
+
+.lfx-changelog-footer-link {
+  color: var(--lfx-changelog-text-link);
+  text-decoration: none;
+  font-size: var(--lfx-changelog-font-size-base);
+  font-weight: 500;
+  transition: color 0.15s ease;
+}
+
+.lfx-changelog-footer-link:hover {
+  color: var(--lfx-changelog-text-link-hover);
+  text-decoration: underline;
+}
+
+/* ── Loading skeleton ─────────────────────────── */
+
+.lfx-changelog-loading {
+  padding: var(--lfx-changelog-card-padding);
+}
+
+.lfx-changelog-skeleton {
+  padding: var(--lfx-changelog-card-padding) 0;
+  border-bottom: 1px solid var(--lfx-changelog-border-color);
+}
+
+.lfx-changelog-skeleton:last-child {
+  border-bottom: none;
+}
+
+.lfx-changelog-skeleton-line {
+  height: 12px;
+  background: var(--lfx-changelog-bg-surface-alt);
+  border-radius: 4px;
+  margin-bottom: 10px;
+  animation: lfx-changelog-shimmer 1.5s infinite;
+}
+
+.lfx-changelog-skeleton-line:nth-child(1) { width: 30%; height: 10px; }
+.lfx-changelog-skeleton-line:nth-child(2) { width: 70%; height: 16px; }
+.lfx-changelog-skeleton-line:nth-child(3) { width: 100%; }
+.lfx-changelog-skeleton-line:nth-child(4) { width: 85%; }
+
+@keyframes lfx-changelog-shimmer {
+  0%, 100% { opacity: 0.4; }
+  50% { opacity: 1; }
+}
+
+/* ── Error state ──────────────────────────────── */
+
+.lfx-changelog-error {
+  padding: calc(var(--lfx-changelog-card-padding) * 2);
+  text-align: center;
+  color: var(--lfx-changelog-text-secondary);
+}
+
+.lfx-changelog-error-icon {
+  font-size: 32px;
+  margin-bottom: 12px;
+  opacity: 0.6;
+}
+
+.lfx-changelog-error-message {
+  margin-bottom: 16px;
+  font-size: var(--lfx-changelog-font-size-base);
+}
+
+.lfx-changelog-retry-btn {
+  padding: 8px 20px;
+  border: 1px solid var(--lfx-changelog-border-color-strong);
+  border-radius: var(--lfx-changelog-border-radius-sm);
+  background: var(--lfx-changelog-bg-surface);
+  color: var(--lfx-changelog-text-primary);
+  font-size: var(--lfx-changelog-font-size-base);
+  cursor: pointer;
+  transition: all 0.15s ease;
+  font-family: inherit;
+}
+
+.lfx-changelog-retry-btn:hover {
+  background: var(--lfx-changelog-bg-surface-alt);
+  border-color: var(--lfx-changelog-accent);
+  color: var(--lfx-changelog-accent);
+}
+
+/* ── Empty state ──────────────────────────────── */
+
+.lfx-changelog-empty {
+  padding: calc(var(--lfx-changelog-card-padding) * 2);
+  text-align: center;
+  color: var(--lfx-changelog-text-muted);
+  font-size: var(--lfx-changelog-font-size-base);
+}
+
+/* ── Responsive ───────────────────────────────── */
+
+@media (max-width: 768px) {
+  :host {
+    --lfx-changelog-card-padding: 16px;
+    --lfx-changelog-font-size-xl: 18px;
+  }
+}
+
+/* ── High contrast mode ───────────────────────── */
+
+@media (prefers-contrast: high) {
+  :host {
+    --lfx-changelog-bg-surface: Canvas;
+    --lfx-changelog-bg-surface-alt: Canvas;
+    --lfx-changelog-text-primary: CanvasText;
+    --lfx-changelog-text-secondary: CanvasText;
+    --lfx-changelog-text-link: LinkText;
+    --lfx-changelog-border-color: CanvasText;
+  }
+}
+
+/* ── Reduced motion ───────────────────────────── */
+
+@media (prefers-reduced-motion: reduce) {
+  .lfx-changelog-card {
+    transition: none;
+  }
+
+  .lfx-changelog-skeleton-line {
+    animation: none;
+    opacity: 0.6;
+  }
+
+  .lfx-changelog-retry-btn,
+  .lfx-changelog-footer-link {
+    transition: none;
+  }
+}
+`;

--- a/src/components/changelog/changelog.types.ts
+++ b/src/components/changelog/changelog.types.ts
@@ -1,0 +1,47 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+/**
+ * A single changelog entry returned by the public API
+ */
+export interface ChangelogEntry {
+  id: string;
+  title: string;
+  description: string;
+  version: string | null;
+  slug: string | null;
+  publishedAt: string | Date | null;
+  createdAt: string | Date;
+  product: {
+    name: string;
+    slug: string;
+  };
+  author: {
+    name: string;
+  } | null;
+}
+
+/**
+ * API response shape for the public changelogs endpoint
+ */
+export interface ChangelogApiResponse {
+  success: boolean;
+  data: ChangelogEntry[];
+  total: number;
+  page: number;
+  pageSize: number;
+}
+
+/**
+ * Attributes accepted by the lfx-changelog element
+ */
+export interface LFXChangelogAttributes {
+  /** Product slug to filter changelogs (required) */
+  product: string;
+  /** Color theme — "light" or "dark" */
+  theme: 'light' | 'dark';
+  /** Maximum number of entries to show (1–25, default 10) */
+  limit: number;
+  /** Override the API base URL (defaults to https://changelog.lfx.dev) */
+  'base-url': string;
+}

--- a/src/components/changelog/changelog.types.ts
+++ b/src/components/changelog/changelog.types.ts
@@ -38,10 +38,10 @@ export interface ChangelogApiResponse {
 export interface LFXChangelogAttributes {
   /** Product slug to filter changelogs (required) */
   product: string;
-  /** Color theme — "light" or "dark" */
-  theme: 'light' | 'dark';
+  /** Color theme — "light" (default) or "dark" */
+  theme?: 'light' | 'dark';
   /** Maximum number of entries to show (1–25, default 10) */
-  limit: number;
+  limit?: number;
   /** Override the API base URL (defaults to https://changelog.lfx.dev) */
-  'base-url': string;
+  'base-url'?: string;
 }

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -1,5 +1,6 @@
 // Copyright The Linux Foundation and each contributor to LFX.
 // SPDX-License-Identifier: MIT
 
+export * from './changelog/changelog.component';
 export * from './footer/footer.component';
 export * from './tools/tools.component';


### PR DESCRIPTION
## Summary

- Add `lfx-changelog` web component that fetches and displays published changelog entries for LFX products
- Shadow DOM with full style encapsulation using `StylesheetManager` (constructible stylesheets with caching)
- Light/dark theme via `theme` attribute, CSS custom properties (`--lfx-changelog-*`), and `::part()` selectors
- Full markdown rendering (marked + DOMPurify for XSS protection)
- Loading skeleton, error + retry, and empty states
- Configurable `product` slug, `limit`, and `base-url` (defaults to prod `https://changelog.lfx.dev`)
- SSR-safe custom element registration
- Browser bundle at `dist/browser/changelog.bundle.js` for CDN usage
- Storybook stories pointing to local dev server (`localhost:4204`)
- Documentation added to `docs/changelog.md`, `docs/components.md`, and `README.md`

### Usage
```html
<lfx-changelog product="easycla" theme="dark" limit="5"></lfx-changelog>
```

### Dependencies added
- `marked` — markdown to HTML
- `dompurify` — XSS sanitization
- `@types/dompurify` (dev) — TypeScript types